### PR TITLE
Add post notion api client & push cmd

### DIFF
--- a/cmd/push.go
+++ b/cmd/push.go
@@ -1,0 +1,48 @@
+/*
+Copyright © 2025 team pascal
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/team-pascal/mnit/internal/service"
+)
+
+var pushCmd = &cobra.Command{
+	Use:     "push <file-name>",
+	Short:   "Push markdown files to notion.",
+	Long:    `Push the file specified by the first argument to notion.`,
+	Example: `  mnit push sample.md`,
+	Args:    cobra.MinimumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if err := service.Push(args); err != nil {
+			fmt.Println(err.Error())
+		}
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(pushCmd)
+}

--- a/internal/infrastructure/notion_api_client.go
+++ b/internal/infrastructure/notion_api_client.go
@@ -1,0 +1,44 @@
+package infrastructure
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+const NOTION_API_URL = "https://api.notion.com/v1/"
+const NOTION_VERSION = "2022-06-28"
+const mimeType = "application/json"
+
+const (
+	PagesEndpoint = NOTION_API_URL + "pages"
+)
+
+func Post(url string, body io.Reader, token string) error {
+	req, err := http.NewRequest("POST", url, body)
+	if err != nil {
+		return errors.New("failed to create request.")
+	}
+	req.Header.Set("Content-Type", mimeType)
+	req.Header.Set("Notion-Version", NOTION_VERSION)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	client := &http.Client{}
+	res, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to post data: %w", err)
+	}
+	defer res.Body.Close()
+
+	resBody, err := io.ReadAll(res.Body)
+	if err != nil {
+		return fmt.Errorf("faile to read response body. %w", err)
+	}
+
+	if res.StatusCode != 200 {
+		return fmt.Errorf("failed to post. status: %d, response: %s", res.StatusCode, string(resBody))
+	}
+
+	return err
+}

--- a/internal/model/notion.go
+++ b/internal/model/notion.go
@@ -1,0 +1,26 @@
+package model
+
+type Parent struct {
+	DatabaseId string `json:"database_id"`
+}
+
+type Text struct {
+	Content string `json:"content"`
+}
+
+type Title struct {
+	Text Text `json:"text"`
+}
+
+type CompanyName struct {
+	Title []Title `json:"title"`
+}
+
+type Properties struct {
+	CompanyName CompanyName `json:"company_name"`
+}
+
+type Page struct {
+	Parent     Parent     `json:"parent"`
+	Properties Properties `json:"properties"`
+}

--- a/internal/service/notion_service.go
+++ b/internal/service/notion_service.go
@@ -1,0 +1,67 @@
+package service
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/team-pascal/mnit/internal/infrastructure"
+	"github.com/team-pascal/mnit/internal/model"
+)
+
+func Push(files []string) error {
+
+	for _, path := range files {
+		if !exists(path) {
+			return fmt.Errorf("the file '%s' was not found.", path)
+		}
+		ex := filepath.Ext(path)
+		if ex != ".md" {
+			return errors.New("invalid file format. markdown files are allowed.")
+		}
+	}
+
+	// Added process to convert files to notion api
+
+	// sample
+	data := model.Page{
+		Parent: model.Parent{
+			DatabaseId: "",
+		},
+		Properties: model.Properties{
+			CompanyName: model.CompanyName{
+				Title: []model.Title{
+					{
+						Text: model.Text{
+							Content: "こんちは",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	jsonData, err := json.Marshal(data)
+	if err != nil {
+		return fmt.Errorf("failed to convert file. %w", err)
+	}
+
+	token, err := GetToken()
+	if err != nil {
+		return err
+	}
+
+	if err := infrastructure.Post(infrastructure.PagesEndpoint, bytes.NewBuffer(jsonData), token); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func exists(path string) bool {
+	_, err := os.Stat(path)
+	return !os.IsNotExist(err)
+}


### PR DESCRIPTION
## **Overview**

- Add notion api client (only post)
- Push command (not perfect)

## **Other**

- Added `notion_service.go` for push command, but did not the process of converting from file data to model.
- `model/notion.go` added for sample
